### PR TITLE
[FIX] release memory

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPReader.cpp
@@ -273,7 +273,8 @@ namespace OpenMS
       sqlite3_step( stmt );
     }
 
-     sqlite3_close(db);
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
 
   }
 


### PR DESCRIPTION
prevents a mem leak:


- The application must finalize every prepared statement in order to avoid resource leaks. It is a grievous error for the application to try to use a prepared statement after it has been finalized. Any use of a prepared statement after it has been finalized can result in undefined and undesirable behavior such as segfaults and heap corruption. 
  - from https://sqlite.org/c3ref/finalize.html


we may even want to check the return value of the finalize...