### PR TITLE
Fix/precision

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPReader.cpp
@@ -273,7 +273,8 @@ namespace OpenMS
       sqlite3_step( stmt );
     }
 
-     sqlite3_close(db);
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
 
   }
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPReader.cpp
@@ -382,6 +382,7 @@ namespace OpenMS
     std::map<int,bool> precursor_decoy_map;
 
     std::stringstream insert_transition_sql, insert_transition_peptide_mapping_sql, insert_transition_precursor_mapping_sql;
+    insert_transition_sql.precision(11);
 
     Size progress = 0;
     startProgress(0, targeted_exp.getPeptides().size(), "Convert peptides");
@@ -477,6 +478,7 @@ namespace OpenMS
     boost::erase(protein_set, boost::unique<boost::return_found_end>(boost::sort(protein_set)));  
 
     std::stringstream insert_precursor_sql, insert_precursor_peptide_mapping, insert_precursor_compound_mapping;
+    insert_precursor_sql.precision(11);
     std::vector<std::pair<int, int> > peptide_protein_map;
 
     progress = 0;


### PR DESCRIPTION
I have seen that the default precision is only 6 on many systems, not enough for a double and it will truncate therefore 401.1234321 to 401.123 which is not accurate enough for precursor/product m/z accureacy. Have you seen that as well?

see also http://en.cppreference.com/w/cpp/io/manip/setprecision